### PR TITLE
BUG-46 Added logic for downloading platform specific tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ ARG TERRAFORM_VERSION
 
 ARG AWSCLI_VERSION=2.7.32
 ARG HCLEDIT_VERSION=0.2.2
+ARG TFAUTOMV_VERSION=0.5.0
+ARG KUBECTL_VERSION=v1.23.15
 
 ################################################################
 ################################################################
@@ -16,6 +18,10 @@ LABEL vendor="Binbash Leverage (info@binbash.com.ar)"
 
 ARG AWSCLI_VERSION
 ARG HCLEDIT_VERSION
+ARG TFAUTOMV_VERSION
+ARG KUBECTL_VERSION
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 ################################
 # System update and intalls
@@ -53,32 +59,48 @@ FROM base AS leverage-base
 ARG TERRAFORM_VERSION
 ARG AWSCLI_VERSION
 ARG HCLEDIT_VERSION
+ARG TFAUTOMV_VERSION
+ARG KUBECTL_VERSION
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+
+################################
+# Setting platform
+################################
+RUN if [  $(echo "${TARGETPLATFORM}" | grep -E "^.*arm64.*$" | wc -l) -gt 0 ]; \
+    then \
+      echo "PLATFORM=arm64" >> .machinetype.env; \
+      echo "AWSPLATFORM=aarch64" >> .machinetype.env; \
+    else \
+      if [  $(echo "${TARGETPLATFORM}" | grep -E "^.*amd64.*$" | wc -l) -gt 0 ]; \
+      then \
+        echo "PLATFORM=amd64" >> .machinetype.env; \
+        echo "AWSPLATFORM=x86_64" >> .machinetype.env; \
+      else \
+        exit 1; \
+      fi; \
+    fi
 
 ################################
 # Install Terraform
 ################################
 
-# Download terraform for linux
-RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-
-# Unzip
-RUN unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-
-# Move to local bin
-RUN mv terraform /usr/local/bin/
-RUN ln -s /usr/local/bin/terraform /bin/terraform
-# Check that it's installed
-RUN terraform --version
+RUN ["/bin/bash", "-c", ". .machinetype.env && \
+    wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${PLATFORM}.zip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_${PLATFORM}.zip && \
+    mv terraform /usr/local/bin/ && \
+    ln -s /usr/local/bin/terraform /bin/terraform && \
+    terraform --version "]
 
 ################################
 # Install AWS CLI
 ################################
 
-# Install AWS CLI v2
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip \
-        && unzip awscliv2.zip \
-        && ./aws/install \
-        && rm -rf awscliv2.zip aws
+RUN ["/bin/bash", "-c", ". .machinetype.env && \
+    curl \"https://awscli.amazonaws.com/awscli-exe-linux-${AWSPLATFORM}-${AWSCLI_VERSION}.zip\" -o awscliv2.zip && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws"]
 
 ################################################################
 ################################################################
@@ -92,47 +114,65 @@ FROM leverage-base AS leverage-toolbox
 ARG TERRAFORM_VERSION
 ARG AWSCLI_VERSION
 ARG HCLEDIT_VERSION
+ARG TFAUTOMV_VERSION
+ARG KUBECTL_VERSION
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 ################################
-# Install
+# Setting platform
+################################
+RUN if [  $(echo "${TARGETPLATFORM}" | grep -E "^.*arm64.*$" | wc -l) -gt 0 ]; \
+    then \
+      echo "PLATFORM=arm64" >> .machinetype.env; \
+      echo "TFAUTOMVPLATFORM=arm64" >> .machinetype.env; \
+    else \
+      if [  $(echo "${TARGETPLATFORM}" | grep -E "^.*amd64.*$" | wc -l) -gt 0 ]; \
+      then \
+        echo "PLATFORM=amd64" >> .machinetype.env; \
+        echo "TFAUTOMVPLATFORM=x86_64" >> .machinetype.env; \
+      else \
+        exit 1; \
+      fi; \
+    fi
+
+################################
+# Install HCLEdit
 ################################
 
-# Install hcledit
-RUN curl -LO "https://github.com/minamijoyo/hcledit/releases/download/v${HCLEDIT_VERSION}/hcledit_${HCLEDIT_VERSION}"_linux_amd64.tar.gz \
-        && tar -xzf hcledit_${HCLEDIT_VERSION}_linux_amd64.tar.gz hcledit \
-        && chmod +x hcledit \
-        && mv hcledit /usr/local/bin/hcledit \
-        && rm hcledit_${HCLEDIT_VERSION}_linux_amd64.tar.gz
+RUN ["/bin/bash", "-c", ". .machinetype.env && \
+    curl -LO \"https://github.com/minamijoyo/hcledit/releases/download/v${HCLEDIT_VERSION}/hcledit_${HCLEDIT_VERSION}_linux_${PLATFORM}.tar.gz\" && \
+    tar -xzf hcledit_${HCLEDIT_VERSION}_linux_${PLATFORM}.tar.gz hcledit && \
+    chmod +x hcledit && \
+    mv hcledit /usr/local/bin/hcledit && \
+    rm hcledit_${HCLEDIT_VERSION}_linux_${PLATFORM}.tar.gz"]
 
 ################################
-# Install
+# Install TFautomv
 ################################
 
-# Install tfautomv
-ARG TFAUTOMV_VERSION="0.5.0"
-RUN curl -LO "https://github.com/padok-team/tfautomv/releases/download/v${TFAUTOMV_VERSION}/tfautomv_${TFAUTOMV_VERSION}_Linux_x86_64.tar.gz" \
-    && tar -xvf tfautomv_${TFAUTOMV_VERSION}_Linux_x86_64.tar.gz \
-    && chmod +x tfautomv \
-    && mv tfautomv /usr/local/bin/tfautomv \
-    && rm tfautomv_${TFAUTOMV_VERSION}_Linux_x86_64.tar.gz
+RUN ["/bin/bash", "-c", ". .machinetype.env && \
+    curl -LO \"https://github.com/padok-team/tfautomv/releases/download/v${TFAUTOMV_VERSION}/tfautomv_${TFAUTOMV_VERSION}_Linux_${TFAUTOMVPLATFORM}.tar.gz\" && \
+    tar -xvf tfautomv_${TFAUTOMV_VERSION}_Linux_${TFAUTOMVPLATFORM}.tar.gz && \
+    chmod +x tfautomv && \
+    mv tfautomv /usr/local/bin/tfautomv && \
+    rm tfautomv_${TFAUTOMV_VERSION}_Linux_${TFAUTOMVPLATFORM}.tar.gz"]
 
 ################################
 # Install Kubectl
 ################################
 
-ARG KUBECTL_VERSION="v1.23.15"
-RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
-    && chmod +x kubectl \
-    && mv kubectl /usr/local/bin/kubectl
+RUN ["/bin/bash", "-c", ". .machinetype.env && \
+    curl -LO \"https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${PLATFORM}/kubectl\" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl"]
 
 ################################
-# Install
+# Install Scripts
 ################################
 
-# Add aws-mfa script
 RUN mkdir -p /root/scripts/aws-mfa
 COPY ./scripts/aws-mfa/aws-mfa-entrypoint.sh  /root/scripts/aws-mfa/aws-mfa-entrypoint.sh
-# Add aws-sso scripts
 RUN mkdir -p /root/scripts/aws-sso
 COPY ./scripts/aws-sso/aws-sso-configure.sh  /root/scripts/aws-sso/aws-sso-configure.sh
 COPY ./scripts/aws-sso/aws-sso-login.sh  /root/scripts/aws-sso/aws-sso-login.sh

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ AWS_REGION            := us-east-1
 AWS_IAM_PROFILE       := bb-apps-devstg-devops
 AWS_DOCKER_ENTRYPOINT := aws
 
+
 # ###############################################################
 # TERRAFORM AND CLI VERSIONS                                    #
 # ###############################################################
@@ -42,6 +43,11 @@ DOCKER_IMG_NAME  := leverage-toolbox
 #
 ADDITIONAL_TAGS := $(shell ((echo "${LEVERAGE_CLI_TAG}" | grep -q -E "\.rc[0-9]+$$") && echo "" ) || echo ${TERRAFORM_TAG}-latest)
 
+#
+# PLATFORMS
+#
+TARGET_PLATFORMS := 'linux/amd64,linux/arm64'
+
 # ###############################################################
 
 #CURRENT_TAG      := $(shell git describe --tags --abbrev=0 2> /dev/null)
@@ -50,7 +56,7 @@ CURRENT_TAG      := $(shell git tag | grep ${DOCKER_TAG})
 #
 # ADDITIONAL ARGS FOR THE DOCKER BUILD PROCESS
 #
-ADDITIONAL_DOCKER_ARGS := "TERRAFORM_VERSION='${TERRAFORM_TAG}'"
+ADDITIONAL_DOCKER_ARGS := "TERRAFORM_VERSION='${TERRAFORM_TAG}',PLATFORM='${PLATFORM}'"
 
 #
 # GIT-RELEASE


### PR DESCRIPTION
## what
* Added logic to Dockerfile for downloading platform specific tools
* Limited in makefile the number of platforms

## why
* Despite the use of buildx for multiplatform builds, the tools inside the dockerfile were downloaded for the wrong target. This fix is intended to download platform specific tools.

## references
* closes https://github.com/binbashar/le-docker-leverage-toolbox/issues/46

